### PR TITLE
Integrating with Frontend-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Re-running of SPMF conformance tests is currently in progress.
 
 ---
 ## How to Install the RedDrum-Simulator 
-#### Manual Install from git clone
+
+#### Manual Install from git clone with edit-able code
 * Install on Centos7.1 or later Linux system
 * Install and configure the Apache httpd 
 
@@ -85,24 +86,26 @@ Re-running of SPMF conformance tests is currently in progress.
      ./subSystem_config.sh # creates a httpd.conf file in etc/httpd and creates self-signed ssl certificates
 ```
 
-* Install the RedDrum-Frontend code
+* Install the RedDrum-Frontend code (with editable code)
 
 ```
      cd  <your_path_to_Directory_Holding_RedDrumSimulator_code>
-     git clone http://github.com/RedDrum-Redfish-Project/RedDrum-Frontend  RedDrum-Frontend
+     git clone http://github.com/RedDrum-Redfish-Project/RedDrum-Frontend  
+     pip install -e ./RedDrum-Frontend
 ```
 
 * Install the RedDrum-Simulator code
 
 ```
      cd  <your_path_to_Directory_Holding_RedDrumSimulator_code>
-     git clone http://github.com/RedDrum-Redfish-Project/RedDrum-Simulator  RedDrum-Simulator  
+     git clone http://github.com/RedDrum-Redfish-Project/RedDrum-Simulator  
 ```
 
 #### Install using `pip install` from github (currently testing)
-* ***currently verifying that installing directly from github using pip install***
+* ***currently working on this***
 
 #### Install using `pip install` from pypi (not working yet)
+* ***currently working on this***
 
 
 ### How to Start  the RedDrum-Simulator

--- a/redDrumSimulatorMain.py
+++ b/redDrumSimulatorMain.py
@@ -109,11 +109,21 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
     #      rdr.logMsg(sev,"message")  # where sev= "INFO" "WARNING" "ERROR" "CRITICAL" "DEBUG"
     #
     # **************************************
-    # *** EDIT THIS TO PUT THE " RedDrum-Frontend " package in the Python Path:
-    # ******** for now, we will add a path to ../RedDrum-Frontend  
+    # *** YOU MUST HAVE THE "reddrum_frontend" package from  RedDrum-Frontend in your Python Path:
     cwd=os.getcwd()
-    defaultFrontendPath=os.path.abspath(os.path.join(cwd,"..","RedDrum-Frontend"))
-    sys.path.append(defaultFrontendPath)
+    # reddrum_frontend should be in the python path
+    # see RedDrum-Frontend README.md for how to install it so that it shows up in the python path under site packages
+    #   for development, clone the Frontend and import with with -e option to allow editing 
+    #     clone https://github.com/RedDrum-Redfish-Project/RedDrum-Frontend
+    #     pip install -e ./RedDrum-Frontend
+    #   If no need to edit the Frontend code--just install the frontend into sitepackages
+    #     pip install git+https://github.com/RedDrum-Redfish-Project/RedDrum-Frontend.git
+    #
+    # to hard code the python-path to a dev RedDrum-Frontend
+    #     defaultFrontendPath=os.path.abspath(os.path.join(cwd,"---joint path over to the repo---","RedDrum-Frontend"))
+    #     sys.path.append(defaultFrontendPath) # add this to the path
+    #     from reddrum_frontend import RdRootData
+    #
     # *** end create path to the Frontend
     # **************************************
 

--- a/scripts/clearCaches
+++ b/scripts/clearCaches
@@ -3,7 +3,7 @@ CWD=`pwd`
 ECWD=$CWD/..
 rm -r -f $ECWD/__pycache__
 
-rm -r -f $ECWD/backend/__pycache__
+rm -r -f $ECWD/reddrum_simulator/__pycache__
 rm -r -f $ECWD/../RedDrum-Frontend/reddrum_frontend/__pycache__
 
 # remove Local RedfishService Database caches under RedfishService: FlaskApp

--- a/scripts/redDrumSimulatorMain
+++ b/scripts/redDrumSimulatorMain
@@ -109,11 +109,21 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
     #      rdr.logMsg(sev,"message")  # where sev= "INFO" "WARNING" "ERROR" "CRITICAL" "DEBUG"
     #
     # **************************************
-    # *** EDIT THIS TO PUT THE " RedDrum-Frontend " package in the Python Path:
-    # ******** for now, we will add a path to ../RedDrum-Frontend  
+    # *** YOU MUST HAVE THE "reddrum_frontend" package from  RedDrum-Frontend in your Python Path:
     cwd=os.getcwd()
-    defaultFrontendPath=os.path.abspath(os.path.join(cwd,"..","RedDrum-Frontend"))
-    sys.path.append(defaultFrontendPath)
+    # reddrum_frontend should be in the python path
+    # see RedDrum-Frontend README.md for how to install it so that it shows up in the python path under site packages
+    #   for development, clone the Frontend and import with with -e option to allow editing 
+    #     clone https://github.com/RedDrum-Redfish-Project/RedDrum-Frontend
+    #     pip install -e ./RedDrum-Frontend
+    #   If no need to edit the Frontend code--just install the frontend into sitepackages
+    #     pip install git+https://github.com/RedDrum-Redfish-Project/RedDrum-Frontend.git
+    #
+    # to hard code the python-path to a dev RedDrum-Frontend
+    #     defaultFrontendPath=os.path.abspath(os.path.join(cwd,"---joint path over to the repo---","RedDrum-Frontend"))
+    #     sys.path.append(defaultFrontendPath) # add this to the path
+    #     from reddrum_frontend import RdRootData
+    #
     # *** end create path to the Frontend
     # **************************************
 

--- a/scripts/runSimulator
+++ b/scripts/runSimulator
@@ -7,5 +7,5 @@ if [ "${profile}" == "" ]; then
 fi
 ./clearCaches
 cd ..
-python3.4 ./redDrumSimulatorMain.py -L --Profile=${profile}
+python3 ./redDrumSimulatorMain.py -L --Profile=${profile}
 


### PR DESCRIPTION
changes here are to align with final cleanup of frontend:
1) changed scripts/runSimulator to use python3 (vs python3.4)
2) mocified redDrumSimulatorMain.py to assume reddrum_frontend is in site-packages
   -- the Frontend setup.py and README.md has been updated to correctly handle instll to site-packages
3) updated README.md to describe installing the frontend with pip install to site packages
4) fixed scripts/clearCaches script to clear the frontend cache correctly