### PR TITLE
support installing RedDrum-Simulator with pip install

### DIFF
--- a/redDrumSimulatorMain.py
+++ b/redDrumSimulatorMain.py
@@ -133,7 +133,8 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
 
     # now calculate the directory path to the FrontEnd Package Directory which has reddrum_frontend/ and reddrum_frontend/Data under it
     # this works even if the Frontend package above was put in site-packages
-    rdr.frontEndDirPath=os.path.abspath(os.path.join(os.path.dirname( inspect.getfile(RdRootData)), ".."))
+    rdr.frontEndPkgPath=os.path.dirname( inspect.getfile(RdRootData))  # return the path to reddrum_frontend
+    rdr.frontEndDirPath=os.path.abspath(os.path.join(rdr.frontEndPkgPath, ".."))
     #print("EEEEEEEEEEEEEEEE DIR: frontend dir: {}".format(rdr.frontEndDirPath))
 
     # initialize root data with passed-in args
@@ -153,8 +154,14 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
     # if you want to create your own, copy the front-end of the RdLogger code and then import your own
     # if you don't set rdr.logger=RdLogger() or your custom logger, then messages are not logged
     loggerName="None"
-    if rdr.isLocal is not True:     
-        from RedfishService import RdLogger         # import the default RedDrum logger
+
+    # set a property to indicate whether to startup a syslog logger for RedDrum
+    # if startSimulatorLogger is True, it will try to create a logger,
+    startSimulatorLogger=False     # **** if False, we wont try to start a logger with the Simulator 
+
+
+    if rdr.isLocal is not True and startSimulatorLogger is True:     
+        from reddrum_frontend import RdLogger         # import the default RedDrum logger
         rdr.rdLogger = RdLogger(rdr.rdServiceName)   # dflt rdLogger=None
         loggerName="RdLogger"
 

--- a/reddrum_simulator/RedDrum.conf
+++ b/reddrum_simulator/RedDrum.conf
@@ -1,0 +1,28 @@
+#
+# This file contains the RedDrum  RedfishService Config parameters.
+# The file should  be re-located to /etc/.../RedDrum.conf and the path
+#    to it should be added to the reddrum_openbmc/backendRoot.py startup() method
+#
+# redDrumMain.py reads this file when it starts to get config info.
+#
+# If this config is modified, the RedfishService should be restarted:
+#
+[Server Section]
+HttpHeaderCacheControl="no-store"
+HttpHeaderServer=None
+HttpHeaderAccessControlAllowOrigin="*"
+IncludeLocalJsonSchemaFiles=false
+IncludeLocalRegistriesFiles=false
+UseLocalJsonSchemaUrlInLinkHeader=false
+ProcessorInfoCacheTimeout=10
+SimpleStorageInfoCacheTimeout=10
+EthernetInterfaceInfoCacheTimeout=10
+MemoryInfoCacheTimeout=10
+
+
+[Auth Section]
+RedfishAllowAuthNone=false
+RedfishAllowAuthenticatedAPIsOverHttp=true
+RedfishAllowBasicAuthOverHttp=true
+RedfishAllowSessionLoginOverHttp=true
+RedfishAllowUserCredUpdateOverHttp=true

--- a/reddrum_simulator/backendRoot.py
+++ b/reddrum_simulator/backendRoot.py
@@ -6,6 +6,7 @@
 import os
 import sys
 import json
+import inspect
 
 # Backend root class for Simulator
 from .chassisBackend   import RdChassisBackend
@@ -46,11 +47,34 @@ class RdBackendRoot():
         # set the data paths for standard Linux
         #   if running w/ -L (isLocal) option, the varDataPath is modified from this by Main
         rdSvcPath=os.getcwd()
-        rdr.baseDataPath=os.path.join(rdSvcPath, "reddrum_frontend", "Data")
-        rdr.varDataPath="/var/www/rf"  
-        rdr.RedDrumConfPath=os.path.join(rdSvcPath, "RedDrum.conf" ) 
-        rdr.staticConfigDataPath=os.path.join(rdSvcPath, "reddrum_simulator", "Data")
-        rdr.schemasPath = os.path.join(rdSvcPath, "schemas")
+
+        # get path to the simulator backend package
+        rdr.simulatorPkgPath=os.path.dirname( inspect.getfile(RdBackendRoot))  
+
+        # get the path to frontend data
+        #rdr.baseDataPath=os.path.join(rdSvcPath, "reddrum_frontend", "Data")
+        rdr.baseDataPath=os.path.join(rdr.frontEndPkgPath, "Data")
+        print("EEEEEEEE: baseDataPath: {}".format(rdr.baseDataPath))
+
+        rdr.varDataPath=os.path.join( "/var", "www", "rf"  )
+        print("EEEEEEEE: varDataPath: {}".format(rdr.varDataPath))
+
+        # if we have a RedDrum.conf file in /etc/ use it. otherwise use the default
+        #rdr.RedDrumConfPath=os.path.join(rdSvcPath, "RedDrum.conf" )
+        redDrumConfPathEtc=os.path.join("/etc",  "RedDrum.conf" )
+        redDrumConfPathFrontend=os.path.join(rdr.frontEndPkgPath, "RedDrum.conf")
+        redDrumConfPathSimulator=os.path.join(rdr.simulatorPkgPath,"RedDrum.conf")
+        if os.path.isfile(redDrumConfPathEtc):
+            rdr.RedDrumConfPath=redDrumConfPathEtc
+        else:
+            rdr.RedDrumConfPath=redDrumConfPathSimulator
+        print("EEEEEEEE: RedDrumConfPath: {}".format(rdr.RedDrumConfPath))
+
+        # get path to Simulator Static config files
+        rdr.staticConfigDataPath=os.path.join(rdr.simulatorPkgPath, "Data")
+        print("EEEEEEEE: StaticConfigDataPaths: {}".format(rdr.staticConfigDataPath))
+
+        rdr.schemasPath = os.path.join(rdSvcPath, "schemas") # not used now
 
         # note that syslog logging is enabled on Simulator by default unless -L (isLocal) option was specified
         # turn-on console messages also however

--- a/scripts/clearCaches
+++ b/scripts/clearCaches
@@ -9,4 +9,5 @@ rm -r -f $ECWD/../RedDrum-Frontend/reddrum_frontend/__pycache__
 # remove Local RedfishService Database caches under RedfishService: FlaskApp
 DBDIR="$ECWD/isLocalData"
 rm -R -f ${DBDIR}
+rm -R -f /var/www/rf
 

--- a/scripts/redDrumSimulatorMain
+++ b/scripts/redDrumSimulatorMain
@@ -133,7 +133,8 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
 
     # now calculate the directory path to the FrontEnd Package Directory which has reddrum_frontend/ and reddrum_frontend/Data under it
     # this works even if the Frontend package above was put in site-packages
-    rdr.frontEndDirPath=os.path.abspath(os.path.join(os.path.dirname( inspect.getfile(RdRootData)), ".."))
+    rdr.frontEndPkgPath=os.path.dirname( inspect.getfile(RdRootData))  # return the path to reddrum_frontend
+    rdr.frontEndDirPath=os.path.abspath(os.path.join(rdr.frontEndPkgPath, ".."))
     #print("EEEEEEEEEEEEEEEE DIR: frontend dir: {}".format(rdr.frontEndDirPath))
 
     # initialize root data with passed-in args
@@ -153,8 +154,14 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
     # if you want to create your own, copy the front-end of the RdLogger code and then import your own
     # if you don't set rdr.logger=RdLogger() or your custom logger, then messages are not logged
     loggerName="None"
-    if rdr.isLocal is not True:     
-        from RedfishService import RdLogger         # import the default RedDrum logger
+
+    # set a property to indicate whether to startup a syslog logger for RedDrum
+    # if startSimulatorLogger is True, it will try to create a logger,
+    startSimulatorLogger=False     # **** if False, we wont try to start a logger with the Simulator 
+
+
+    if rdr.isLocal is not True and startSimulatorLogger is True:     
+        from reddrum_frontend import RdLogger         # import the default RedDrum logger
         rdr.rdLogger = RdLogger(rdr.rdServiceName)   # dflt rdLogger=None
         loggerName="RdLogger"
 

--- a/scripts/runSimulatorLocal
+++ b/scripts/runSimulatorLocal
@@ -6,5 +6,6 @@ if [ "${profile}" == "" ]; then
    exit 1
 fi
 ./clearCaches
-python3 redDrumSimulatorMain  --Profile=${profile}
+cd ..
+python3 ./redDrumSimulatorMain.py -L --Profile=${profile}
 

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,9 @@ setup(name='RedDrum-Simulator',
           'pytz'                     # used by Frontend
       ],
       include_package_data = True,
-      package_data={'':['*.json', '*.xml', '*.conf']}
+      package_data={'reddrum_simulator': [
+        'RedDrum.conf',
+        'Data/BaseServer1/chassisDb/*.json', 'Data/BaseServer1/managersDb/*.json', 'Data/BaseServer1/systemsDb/*.json',
+        'Data/Dss9000-4nodes/chassisDb/*.json', 'Data/Dss9000-4nodes/managersDb/*.json', 'Data/Dss9000-4nodes/systemsDb/*.json'
+        ]}
 )


### PR DESCRIPTION
updated setup.py to install into site-packages properly with pip install.
also turned off syslog logging  until we test this more.
Also removed the -L (isLocal) option in scripts/sunSimulator 
   --so the data is cached at /var/www/rf... instead of under the pkg.
   --the -L option is just used for special dev use when you are running from editable repo and 
       don't want to put data under any of the system areas